### PR TITLE
Add MARKET_FILLS channel + getMarketFills REST method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export {
   type GetOrdersParams,
   type GetTradesParams,
   type GetFillsParams,
+  type GetMarketFillsParams,
   type GetTokensParams,
   type GetMarketParams,
   type GetMarketsParams,

--- a/src/services/onchainLobSpotService/onchainLobSpotService.ts
+++ b/src/services/onchainLobSpotService/onchainLobSpotService.ts
@@ -1,5 +1,5 @@
 import type { CandleDto, FillDto, LimitDetailsDto, MarketDetailsDto, MarketDto, OrderDto, OrderHistoryDto, OrderbookDto, TokenDto, TradeDto, UserBalancesDto, UserDepositsDto, ClobDepthDto } from './dtos';
-import type { CalculateLimitDetailsParams, CalculateMarketDetailsParams, GetCandlesParams, GetFillsParams, GetMarketsParams, GetOrderbookParams, GetOrderHistoryParams, GetOrdersParams, GetTokensParams, GetTradesParams, GetUserBalancesParams, GetUserDepositsParams, GetClobDepthParams } from './params';
+import type { CalculateLimitDetailsParams, CalculateMarketDetailsParams, GetCandlesParams, GetFillsParams, GetMarketFillsParams, GetMarketsParams, GetOrderbookParams, GetOrderHistoryParams, GetOrdersParams, GetTokensParams, GetTradesParams, GetUserBalancesParams, GetUserDepositsParams, GetClobDepthParams } from './params';
 import { guards } from '../../utils';
 import { RemoteService } from '../remoteService';
 import { ALL_MARKETS_ID } from '../constants';
@@ -119,6 +119,24 @@ export class OnchainLobSpotService extends RemoteService {
     const queryParams = new URLSearchParams({
       market: params.market,
       user: params.user,
+    });
+    if (params.limit)
+      queryParams.append('limit', params.limit.toString());
+
+    const queryParamsString = decodeURIComponent(queryParams.toString());
+    const response = await this.fetch<FillDto[]>(`/fills?${queryParamsString}`, 'json');
+
+    return response;
+  }
+
+  /**
+   * Retrieves the fills for a given market across all users.
+   * @param params - The parameters for the market fills request.
+   * @returns The fills data.
+   */
+  async getMarketFills(params: GetMarketFillsParams): Promise<FillDto[]> {
+    const queryParams = new URLSearchParams({
+      market: params.market,
     });
     if (params.limit)
       queryParams.append('limit', params.limit.toString());

--- a/src/services/onchainLobSpotService/params.ts
+++ b/src/services/onchainLobSpotService/params.ts
@@ -35,6 +35,11 @@ export interface GetFillsParams {
   limit?: number;
 }
 
+export interface GetMarketFillsParams {
+  market: string;
+  limit?: number;
+}
+
 export interface GetTokensParams {
   token?: string;
 }

--- a/src/services/onchainLobSpotWebSocketService/onchainLobSpotWebSocketService.ts
+++ b/src/services/onchainLobSpotWebSocketService/onchainLobSpotWebSocketService.ts
@@ -17,6 +17,7 @@ import type {
   SubscribeToUserOrdersParams, UnsubscribeFromUserOrdersParams,
   SubscribeToUserOrderHistoryParams, UnsubscribeFromUserOrderHistoryParams,
   SubscribeToUserFillsParams, UnsubscribeFromUserFillsParams,
+  SubscribeToMarketFillsParams, UnsubscribeFromMarketFillsParams,
   SubscribeToCandlesParams,
   UnsubscribeFromCandlesParams
 } from './params';
@@ -38,6 +39,7 @@ interface OnchainLobSpotWebSocketServiceEvents {
   userOrdersUpdated: PublicEventEmitter<readonly [marketId: string, isSnapshot: boolean, data: OrderUpdateDto[]]>;
   userOrderHistoryUpdated: PublicEventEmitter<readonly [marketId: string, isSnapshot: boolean, data: OrderHistoryUpdateDto[]]>;
   userFillsUpdated: PublicEventEmitter<readonly [marketId: string, isSnapshot: boolean, data: FillUpdateDto[]]>;
+  marketFillsUpdated: PublicEventEmitter<readonly [marketId: string, isSnapshot: boolean, data: FillUpdateDto[]]>;
   candlesUpdated: PublicEventEmitter<readonly [marketId: string, isSnapshot: boolean, data: CandleUpdateDto]>;
   subscriptionError: PublicEventEmitter<readonly [error: string]>;
 }
@@ -61,6 +63,7 @@ export class OnchainLobSpotWebSocketService implements Disposable {
     userOrdersUpdated: new EventEmitter(),
     userOrderHistoryUpdated: new EventEmitter(),
     userFillsUpdated: new EventEmitter(),
+    marketFillsUpdated: new EventEmitter(),
     candlesUpdated: new EventEmitter(),
   };
 
@@ -280,6 +283,30 @@ export class OnchainLobSpotWebSocketService implements Disposable {
   }
 
   /**
+   * Subscribes to all fills on a given market across all users.
+   * @param params - The parameters for the market fills subscription.
+   */
+  subscribeToMarketFills(params: SubscribeToMarketFillsParams) {
+    this.startOnchainLobWebSocketClientIfNeeded();
+
+    this.onchainLobWebSocketClient.subscribe({
+      channel: 'marketFills',
+      market: params.market,
+    });
+  }
+
+  /**
+   * Unsubscribes from all-users fill updates for a given market.
+   * @param params - The parameters for the market fills unsubscription.
+   */
+  unsubscribeFromMarketFills(params: UnsubscribeFromMarketFillsParams) {
+    this.onchainLobWebSocketClient.unsubscribe({
+      channel: 'marketFills',
+      market: params.market,
+    });
+  }
+
+  /**
    * Subscribes to candle updates for a given market and resolution.
    * @param params - The parameters for the candle subscription.
    */
@@ -353,6 +380,9 @@ export class OnchainLobSpotWebSocketService implements Disposable {
           break;
         case 'userFills':
           (this.events.userFillsUpdated as ToEventEmitter<typeof this.events.userFillsUpdated>).emit(message.id, message.isSnapshot, message.data as FillUpdateDto[]);
+          break;
+        case 'marketFills':
+          (this.events.marketFillsUpdated as ToEventEmitter<typeof this.events.marketFillsUpdated>).emit(message.id, message.isSnapshot, message.data as FillUpdateDto[]);
           break;
         case 'candles':
           (this.events.candlesUpdated as ToEventEmitter<typeof this.events.candlesUpdated>).emit(message.id, message.isSnapshot, message.data as CandleUpdateDto);

--- a/src/services/onchainLobSpotWebSocketService/params.ts
+++ b/src/services/onchainLobSpotWebSocketService/params.ts
@@ -39,6 +39,11 @@ export interface SubscribeToUserFillsParams {
 }
 export type UnsubscribeFromUserFillsParams = SubscribeToUserFillsParams;
 
+export interface SubscribeToMarketFillsParams {
+  market: string;
+}
+export type UnsubscribeFromMarketFillsParams = SubscribeToMarketFillsParams;
+
 export interface SubscribeToCandlesParams {
   market: string;
   resolution: CandleResolution;

--- a/src/spot/index.ts
+++ b/src/spot/index.ts
@@ -19,6 +19,7 @@ export type {
   GetOrderHistoryParams,
   GetTradesParams,
   GetFillsParams,
+  GetMarketFillsParams,
   GetTokensParams,
   GetMarketParams,
   GetMarketsParams,

--- a/src/spot/onchainLobSpot.ts
+++ b/src/spot/onchainLobSpot.ts
@@ -12,6 +12,7 @@ import type {
   ClaimOrderSpotParams,
   DepositSpotParams,
   GetFillsParams,
+  GetMarketFillsParams,
   GetMarketParams,
   GetMarketsParams,
   GetOrderbookParams,
@@ -27,12 +28,14 @@ import type {
   SubscribeToClobDepthParams,
   SubscribeToTradesParams,
   SubscribeToUserFillsParams,
+  SubscribeToMarketFillsParams,
   SubscribeToUserOrdersParams,
   UnsubscribeFromMarketParams,
   UnsubscribeFromOrderbookParams,
   UnsubscribeFromClobDepthParams,
   UnsubscribeFromTradesParams,
   UnsubscribeFromUserFillsParams,
+  UnsubscribeFromMarketFillsParams,
   UnsubscribeFromUserOrdersParams,
   WithdrawSpotParams,
   SubscribeToCandlesParams,
@@ -203,6 +206,13 @@ interface OnchainLobSpotEvents {
   userFillsUpdated: PublicEventEmitter<readonly [marketId: string, isSnapshot: boolean, data: FillUpdate[]]>;
 
   /**
+   * Emitted when fills on a market are updated (across all users).
+   * @event
+   * @type {PublicEventEmitter<readonly [marketId: string, isSnapshot: boolean, data: FillUpdate[]]>}
+   */
+  marketFillsUpdated: PublicEventEmitter<readonly [marketId: string, isSnapshot: boolean, data: FillUpdate[]]>;
+
+  /**
    * Emitted when a market's candle is updated.
    * @event
    * @type {PublicEventEmitter<readonly [marketId: string, isSnapshot: boolean, data: CandleUpdate[]]>}
@@ -238,6 +248,7 @@ export class OnchainLobSpot implements Disposable {
     userOrdersUpdated: new EventEmitter(),
     userOrderHistoryUpdated: new EventEmitter(),
     userFillsUpdated: new EventEmitter(),
+    marketFillsUpdated: new EventEmitter(),
     candlesUpdated: new EventEmitter(),
     allMarketUpdated: new EventEmitter(),
   };
@@ -667,6 +678,22 @@ export class OnchainLobSpot implements Disposable {
   }
 
   /**
+   * Retrieves all fills on the specified market across all users.
+   *
+   * @param {GetMarketFillsParams} params - The parameters for retrieving the market fills.
+   * @returns {Promise<Fill[]>} A Promise that resolves to an array of fills.
+   */
+  async getMarketFills(params: GetMarketFillsParams): Promise<Fill[]> {
+    const [market, fillDtos] = await Promise.all([
+      this.ensureMarket(params),
+      this.onchainLobService.getMarketFills(params),
+    ]);
+    const fills = fillDtos.map(fillDto => this.mappers.mapFillDtoToFill(fillDto, market.priceScalingFactor, market.tokenXScalingFactor, market.tokenYScalingFactor));
+
+    return fills;
+  }
+
+  /**
    * Retrieves the candles for the specified market and resolution.
    *
    * @param {GetCandlesParams} params - The parameters for retrieving the candles.
@@ -895,6 +922,26 @@ export class OnchainLobSpot implements Disposable {
   }
 
   /**
+   * Subscribes to all-users fill updates for the specified market.
+   *
+   * @param {SubscribeToMarketFillsParams} params - The parameters for subscribing to the market fills updates.
+   * @emits OnchainLobSpot#events#marketFillsUpdated
+   */
+  subscribeToMarketFills(params: SubscribeToMarketFillsParams): void {
+    this.onchainLobWebSocketService.subscribeToMarketFills(params);
+  }
+
+  /**
+   * Unsubscribes from all-users fill updates for the specified market.
+   *
+   * @param {UnsubscribeFromMarketFillsParams} params - The parameters for unsubscribing from the market fills updates.
+   * @emits OnchainLobSpot#events#marketFillsUpdated
+   */
+  unsubscribeFromMarketFills(params: UnsubscribeFromMarketFillsParams): void {
+    this.onchainLobWebSocketService.unsubscribeFromMarketFills(params);
+  }
+
+  /**
    * Subscribes to candle updates for the specified market and resolution.
    *
    * @param {SubscribeToCandlesParams} params - The parameters for subscribing to the candle updates.
@@ -959,6 +1006,7 @@ export class OnchainLobSpot implements Disposable {
     this.onchainLobWebSocketService.events.userOrdersUpdated.addListener(this.onUserOrdersUpdated);
     this.onchainLobWebSocketService.events.userOrderHistoryUpdated.addListener(this.onUserOrderHistoryUpdated);
     this.onchainLobWebSocketService.events.userFillsUpdated.addListener(this.onUserFillsUpdated);
+    this.onchainLobWebSocketService.events.marketFillsUpdated.addListener(this.onMarketFillsUpdated);
     this.onchainLobWebSocketService.events.candlesUpdated.addListener(this.onCandlesUpdated);
     this.onchainLobWebSocketService.events.subscriptionError.addListener(this.onSubscriptionError);
   }
@@ -971,6 +1019,7 @@ export class OnchainLobSpot implements Disposable {
     this.onchainLobWebSocketService.events.userOrdersUpdated.removeListener(this.onUserOrdersUpdated);
     this.onchainLobWebSocketService.events.userOrderHistoryUpdated.removeListener(this.onUserOrderHistoryUpdated);
     this.onchainLobWebSocketService.events.userFillsUpdated.removeListener(this.onUserFillsUpdated);
+    this.onchainLobWebSocketService.events.marketFillsUpdated.removeListener(this.onMarketFillsUpdated);
     this.onchainLobWebSocketService.events.candlesUpdated.removeListener(this.onCandlesUpdated);
     this.onchainLobWebSocketService.events.subscriptionError.removeListener(this.onSubscriptionError);
   }
@@ -1099,6 +1148,25 @@ export class OnchainLobSpot implements Disposable {
       });
 
       (this.events.userFillsUpdated as ToEventEmitter<typeof this.events.userFillsUpdated>).emit(marketId, isSnapshot, fillUpdates);
+    }
+    catch (error) {
+      console.error(getErrorLogMessage(error));
+    }
+  };
+
+  protected onMarketFillsUpdated: Parameters<typeof this.onchainLobWebSocketService.events.marketFillsUpdated['addListener']>[0] = async (marketId, isSnapshot, data) => {
+    try {
+      const markets = await this.getCachedMarkets();
+      if (!markets)
+        return;
+      const fillUpdates = data.map(dto => {
+        const market = markets.get(dto.market.id);
+        if (!market)
+          throw new Error(`Market not found for marketId: ${dto.market.id}`);
+        return this.mappers.mapFillUpdateDtoToFillUpdate(marketId, dto, market.priceScalingFactor, market.tokenXScalingFactor, market.tokenYScalingFactor);
+      });
+
+      (this.events.marketFillsUpdated as ToEventEmitter<typeof this.events.marketFillsUpdated>).emit(marketId, isSnapshot, fillUpdates);
     }
     catch (error) {
       console.error(getErrorLogMessage(error));

--- a/src/spot/params.ts
+++ b/src/spot/params.ts
@@ -777,6 +777,23 @@ export interface GetFillsParams {
   limit?: number;
 }
 
+export interface GetMarketFillsParams {
+  /**
+   * Id of the requested market
+   *
+   * @type {string}
+   */
+  market: string;
+  /**
+   * Number of fills to retrieve
+   *
+   * @type {number}
+   * @optional
+   * @default 100
+   */
+  limit?: number;
+}
+
 export interface GetTokensParams {
   token?: string;
 }
@@ -951,6 +968,11 @@ export interface SubscribeToUserFillsParams {
   market?: string;
 }
 export type UnsubscribeFromUserFillsParams = SubscribeToUserFillsParams;
+
+export interface SubscribeToMarketFillsParams {
+  market: string;
+}
+export type UnsubscribeFromMarketFillsParams = SubscribeToMarketFillsParams;
 
 export interface SubscribeToCandlesParams {
   market: string;


### PR DESCRIPTION
- new SubscribeToMarketFillsParams (market only, no user) and matching marketFillsUpdated event emitting [marketId, isSnapshot, FillUpdate[]]
- subscribeToMarketFills / unsubscribeFromMarketFills on both OnchainLobSpotWebSocketService and OnchainLobSpot
- new GetMarketFillsParams and getMarketFills() that GET /fills?market=...
- 'marketFills' case wired in the WS dispatch switch
- GetMarketFillsParams re-exported from src/index.ts and spot/index.ts

Existing getFills() / subscribeToUserFills() behaviour unchanged.