### PR TITLE
Add reconnect() and isConnected to WebSocket clients

### DIFF
--- a/src/common/onchainLobWebSocketClient/onchainLobWebSocketClient.test.ts
+++ b/src/common/onchainLobWebSocketClient/onchainLobWebSocketClient.test.ts
@@ -1,0 +1,131 @@
+import { OnchainLobWebSocketClient } from './onchainLobWebSocketClient';
+import { EventEmitter } from '../eventEmitter';
+import { ReadyState } from '../webSocketClient';
+
+class FakeSocket {
+  events = {
+    messageReceived: new EventEmitter<readonly [message: unknown]>(),
+    opened: new EventEmitter(),
+    closed: new EventEmitter(),
+  };
+
+  readyState: ReadyState = ReadyState.Closed;
+
+  connect = jest.fn(async () => {
+    this.readyState = ReadyState.Open;
+  });
+
+  disconnect = jest.fn(() => {
+    this.readyState = ReadyState.Closed;
+  });
+
+  send = jest.fn();
+
+  emitClosed(reason = 'test') {
+    (this.events.closed as unknown as { emit: (s: unknown, e: unknown) => void }).emit(this, { reason });
+  }
+}
+
+const createClient = () => {
+  const client = new OnchainLobWebSocketClient('wss://example.test');
+  const fake = new FakeSocket();
+  (client as unknown as { socket: FakeSocket }).socket = fake;
+  return { client, fake };
+};
+
+const TRADES_SUBSCRIPTION = { channel: 'trades', market: 'X' };
+
+describe('OnchainLobWebSocketClient.isConnected', () => {
+  it('is false (does not throw) before the socket has ever connected', () => {
+    // Uses the real underlying WebSocketClient, whose readyState previously
+    // threw when no socket had been created yet (lazy / connect-on-demand mode).
+    const client = new OnchainLobWebSocketClient('wss://example.test');
+
+    expect(() => client.isConnected).not.toThrow();
+    expect(client.isConnected).toBe(false);
+  });
+});
+
+describe('OnchainLobWebSocketClient.reconnect', () => {
+  it('performs the initial connect when the client was never started', async () => {
+    const { client, fake } = createClient();
+
+    await client.reconnect();
+
+    expect(fake.connect).toHaveBeenCalledTimes(1);
+    expect(client.isConnected).toBe(true);
+    expect(client.isStarted).toBe(true);
+  });
+
+  it('reopens the socket and re-sends existing subscriptions after a drop', async () => {
+    const { client, fake } = createClient();
+    await client.start();
+    client.subscribe(TRADES_SUBSCRIPTION);
+
+    // Socket drops while the tab is hidden.
+    fake.readyState = ReadyState.Closed;
+    fake.connect.mockClear();
+    fake.send.mockClear();
+
+    await client.reconnect();
+
+    expect(fake.connect).toHaveBeenCalledTimes(1);
+    expect(client.isConnected).toBe(true);
+    expect(fake.send).toHaveBeenCalledWith({ method: 'subscribe', subscription: TRADES_SUBSCRIPTION });
+  });
+
+  it('is a no-op when the socket is already open', async () => {
+    const { client, fake } = createClient();
+    await client.start();
+    fake.connect.mockClear();
+
+    await client.reconnect();
+
+    expect(fake.connect).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates overlapping connects into a single socket connect', async () => {
+    const { client, fake } = createClient();
+
+    // Hold the socket in a connecting state so both connect() calls overlap.
+    let finishConnect!: () => void;
+    fake.connect.mockImplementation(() => new Promise<void>(resolve => {
+      finishConnect = () => {
+        fake.readyState = ReadyState.Open;
+        resolve();
+      };
+    }));
+
+    const connect = () => (client as unknown as { connect(): Promise<void> }).connect();
+    const first = connect();
+    const second = connect();
+
+    finishConnect();
+    await Promise.all([first, second]);
+
+    expect(fake.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the pending backoff reconnect so the socket connects only once', async () => {
+    jest.useFakeTimers();
+    try {
+      const { client, fake } = createClient();
+      await client.start();
+
+      // Socket dropped → background loop schedules a backoff reconnect.
+      fake.readyState = ReadyState.Closed;
+      fake.emitClosed();
+      fake.connect.mockClear();
+
+      await client.reconnect();
+      expect(fake.connect).toHaveBeenCalledTimes(1);
+
+      // The previously-scheduled backoff attempt must not fire a second connect.
+      await jest.advanceTimersByTimeAsync(120000);
+      expect(fake.connect).toHaveBeenCalledTimes(1);
+    }
+    finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/common/onchainLobWebSocketClient/onchainLobWebSocketClient.ts
+++ b/src/common/onchainLobWebSocketClient/onchainLobWebSocketClient.ts
@@ -27,6 +27,8 @@ export class OnchainLobWebSocketClient implements Disposable {
 
   private _isStarted = false;
   private _isStarting = false;
+  private _isReconnecting = false;
+  private _connectPromise: Promise<void> | undefined;
 
   constructor(baseUrl: string) {
     this.baseUrl = textUtils.trimSlashes(baseUrl);
@@ -35,6 +37,10 @@ export class OnchainLobWebSocketClient implements Disposable {
 
   get isStarted() {
     return this._isStarted;
+  }
+
+  get isConnected() {
+    return this.isSocketOpen;
   }
 
   protected get isSocketOpen() {
@@ -71,6 +77,45 @@ export class OnchainLobWebSocketClient implements Disposable {
 
     this._isStarted = false;
     this._isStarting = false;
+  }
+
+  /**
+   * Forces an immediate reconnect, bypassing the escalated backoff of the
+   * background reconnect loop. Intended for the case where the socket was
+   * closed while the page was hidden/frozen (browsers throttle the reconnect
+   * timers) and the user just returned — data should resume without waiting
+   * out a tens-of-seconds backoff delay.
+   *
+   * Existing subscriptions are preserved and re-sent on the fresh socket.
+   * A no-op when the socket is already open.
+   */
+  async reconnect(): Promise<void> {
+    if (this._isReconnecting)
+      return;
+
+    this._isReconnecting = true;
+    try {
+      // Not started yet → a normal start performs the initial connect.
+      if (!this.isStarted && !this._isStarting) {
+        await this.start();
+        return;
+      }
+
+      // Cancel any pending backoff attempt and reset the escalation so we
+      // don't inherit a delay the background reconnect loop grew to tens of
+      // seconds.
+      this.reconnectScheduler.reset();
+
+      // Already connected → nothing to do.
+      if (this.isSocketOpen)
+        return;
+
+      // connect() opens a fresh socket and re-subscribes all subscriptions.
+      await this.connect();
+    }
+    finally {
+      this._isReconnecting = false;
+    }
   }
 
   subscribe(subscriptionData: SubscriptionData): number {
@@ -128,7 +173,23 @@ export class OnchainLobWebSocketClient implements Disposable {
     this.stop();
   }
 
-  protected async connect(): Promise<void> {
+  protected connect(): Promise<void> {
+    // Deduplicate concurrent connects. Without this, a manual reconnect() that
+    // overlaps an already-in-flight connect (the background backoff timer that
+    // just fired, or an initial start()) would open a second socket — the
+    // second connect's internal disconnect() orphans the first, leaking its
+    // unresolved promise and re-sending every subscription needlessly.
+    if (!this._connectPromise) {
+      this._connectPromise = this.performConnect()
+        .finally(() => {
+          this._connectPromise = undefined;
+        });
+    }
+
+    return this._connectPromise;
+  }
+
+  protected async performConnect(): Promise<void> {
     await this.socket.connect();
 
     this.subscribeToAllSubscriptions();

--- a/src/common/timeoutScheduler.test.ts
+++ b/src/common/timeoutScheduler.test.ts
@@ -1,0 +1,44 @@
+import { TimeoutScheduler } from './timeoutScheduler';
+
+describe('TimeoutScheduler.reset', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('cancels a pending scheduled action', async () => {
+    const scheduler = new TimeoutScheduler([1000, 5000]);
+    const action = jest.fn();
+
+    void scheduler.setTimeout(action);
+    scheduler.reset();
+    jest.advanceTimersByTime(10000);
+
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('resets the escalation counter so the next timeout starts from the first step', () => {
+    const scheduler = new TimeoutScheduler([1000, 5000, 30000]);
+
+    void scheduler.setTimeout(() => {});
+    void scheduler.setTimeout(() => {});
+    expect(scheduler.counter).toBe(2);
+
+    scheduler.reset();
+    expect(scheduler.counter).toBe(0);
+
+    const action = jest.fn();
+    void scheduler.setTimeout(action);
+    // Counter was reset → first (1000ms) step, not the escalated 30000ms one.
+    jest.advanceTimersByTime(1000);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the counter-expiration watcher', () => {
+    const scheduler = new TimeoutScheduler([1000], 120000);
+
+    void scheduler.setTimeout(() => {});
+    scheduler.reset();
+
+    // No pending timers should remain after a reset.
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/src/common/timeoutScheduler.ts
+++ b/src/common/timeoutScheduler.ts
@@ -27,8 +27,7 @@ export class TimeoutScheduler implements Disposable {
   constructor(
     private readonly timeouts: number[],
     private readonly counterExpirationMs?: number
-  ) {
-  }
+  ) {}
 
   get counter() {
     return this._counter;
@@ -47,8 +46,7 @@ export class TimeoutScheduler implements Disposable {
 
   setTimeout(action: () => void | Promise<void>): Promise<void> {
     return new Promise(resolve => {
-      if (this.counterExpirationMs)
-        this.resetCounterExpiration();
+      if (this.counterExpirationMs) this.resetCounterExpiration();
 
       const timeoutIndex = Math.min(this.counter, this.timeouts.length - 1);
       const timeout = this.timeouts[timeoutIndex];
@@ -67,6 +65,23 @@ export class TimeoutScheduler implements Disposable {
 
   resetCounter() {
     this.counter = 0;
+  }
+
+  /**
+   * Cancels any pending scheduled action and counter-expiration watcher, and
+   * resets the escalation counter. Use this to force an immediate retry that
+   * isn't stuck waiting out an escalated backoff delay
+   */
+  reset() {
+    this.actionWatchers.forEach(watcher => clearTimeout(watcher));
+    this.actionWatchers.clear();
+
+    if (this.counterExpirationWatcherId) {
+      clearTimeout(this.counterExpirationWatcherId);
+      this.counterExpirationWatcherId = undefined;
+    }
+
+    this.resetCounter();
   }
 
   private resetCounterExpiration() {

--- a/src/common/webSocketClient/index.browser.ts
+++ b/src/common/webSocketClient/index.browser.ts
@@ -1,4 +1,5 @@
 import type { WebSocketClient as WebSocketClientInterface } from './shared';
+import { ReadyState } from './shared';
 import { EventEmitter, type ToEventEmitter } from '../eventEmitter';
 
 export type WebSocketOpenEvent = WebSocketEventMap['open'];
@@ -12,7 +13,9 @@ export class WebSocketClient implements WebSocketClientInterface<WebSocketClient
   };
 
   get readyState() {
-    return this.socket.readyState;
+    // No socket yet (never connected, or connect never called) → report Closed
+    // instead of throwing via the `socket` getter.
+    return this._socket?.readyState ?? ReadyState.Closed;
   }
 
   protected _socket: WebSocket | undefined;

--- a/src/common/webSocketClient/index.node.ts
+++ b/src/common/webSocketClient/index.node.ts
@@ -1,6 +1,7 @@
 import { WebSocket, type Event, type MessageEvent, type ErrorEvent, type CloseEvent } from 'ws';
 
 import type { WebSocketClient as WebSocketClientInterface } from './shared';
+import { ReadyState } from './shared';
 import { EventEmitter, type ToEventEmitter } from '../eventEmitter';
 
 export type WebSocketOpenEvent = Event;
@@ -14,7 +15,9 @@ export class WebSocketClient implements WebSocketClientInterface<WebSocketClient
   };
 
   get readyState() {
-    return this.socket.readyState;
+    // No socket yet (never connected, or connect never called) → report Closed
+    // instead of throwing via the `socket` getter.
+    return this._socket?.readyState ?? ReadyState.Closed;
   }
 
   protected _socket: WebSocket | undefined;

--- a/src/onchainLobClient.ts
+++ b/src/onchainLobClient.ts
@@ -114,4 +114,13 @@ export class OnchainLobClient {
     this.spot.setSigner(signer);
     this.vault.setSigner(signer);
   }
+
+  /**
+   * Forces an immediate reconnect of both the spot and vault WebSockets,
+   * preserving all active subscriptions.
+   */
+  reconnect(): void {
+    this.spot.reconnect();
+    this.vault.reconnect();
+  }
 }

--- a/src/services/onchainLobSpotWebSocketService/onchainLobSpotWebSocketService.ts
+++ b/src/services/onchainLobSpotWebSocketService/onchainLobSpotWebSocketService.ts
@@ -341,6 +341,24 @@ export class OnchainLobSpotWebSocketService implements Disposable {
   }
 
   /**
+   * Whether the underlying WebSocket connection is currently open.
+   */
+  get isConnected(): boolean {
+    return this.onchainLobWebSocketClient.isConnected;
+  }
+
+  /**
+   * Forces an immediate reconnect of the underlying WebSocket, preserving all
+   * active subscriptions. Use when the socket may have been dropped while the
+   * page was hidden/frozen and you want data to resume without waiting out the
+   * background reconnect backoff.
+   */
+  reconnect(): void {
+    this.onchainLobWebSocketClient.reconnect()
+      .catch(error => console.error(`Onchain LOB Web Socket reconnect failed. Error = ${getErrorLogMessage(error)}`));
+  }
+
+  /**
    * Starts the WebSocket client if it is not already started.
    */
   protected startOnchainLobWebSocketClientIfNeeded() {

--- a/src/services/onchainLobVaultWebSocketService/onchainLobVaultWebSocketService.ts
+++ b/src/services/onchainLobVaultWebSocketService/onchainLobVaultWebSocketService.ts
@@ -184,6 +184,24 @@ export class OnchainLobVaultWebSocketService implements Disposable {
   }
 
   /**
+   * Whether the underlying WebSocket connection is currently open.
+   */
+  get isConnected(): boolean {
+    return this.onchainLobWebSocketClient.isConnected;
+  }
+
+  /**
+   * Forces an immediate reconnect of the underlying WebSocket, preserving all
+   * active subscriptions. Use when the socket may have been dropped while the
+   * page was hidden/frozen and you want data to resume without waiting out the
+   * background reconnect backoff.
+   */
+  reconnect(): void {
+    this.onchainLobWebSocketClient.reconnect()
+      .catch(error => console.error(`Onchain LOB Web Socket reconnect failed. Error = ${getErrorLogMessage(error)}`));
+  }
+
+  /**
    * Starts the WebSocket client if it is not already started.
    */
   protected startOnchainLobWebSocketClientIfNeeded() {

--- a/src/spot/onchainLobSpot.ts
+++ b/src/spot/onchainLobSpot.ts
@@ -766,6 +766,23 @@ export class OnchainLobSpot implements Disposable {
   }
 
   /**
+   * Whether the spot WebSocket connection is currently open.
+   */
+  get isConnected(): boolean {
+    return this.onchainLobWebSocketService.isConnected;
+  }
+
+  /**
+   * Forces an immediate reconnect of the spot WebSocket, preserving all active
+   * subscriptions. Use when the socket may have been dropped while the page was
+   * hidden/frozen and you want data to resume without waiting out the background
+   * reconnect backoff.
+   */
+  reconnect(): void {
+    this.onchainLobWebSocketService.reconnect();
+  }
+
+  /**
    * Subscribes to the market updates for the specified market.
    *
    * @param {SubscribeToMarketParams} params - The parameters for subscribing to the market updates.

--- a/src/vault/onchainLobVault.ts
+++ b/src/vault/onchainLobVault.ts
@@ -438,6 +438,23 @@ export class OnchainLobVault {
   }
 
   /**
+   * Whether the vault WebSocket connection is currently open.
+   */
+  get isConnected(): boolean {
+    return this.onchainLobWebSocketService.isConnected;
+  }
+
+  /**
+   * Forces an immediate reconnect of the vault WebSocket, preserving all active
+   * subscriptions. Use when the socket may have been dropped while the page was
+   * hidden/frozen and you want data to resume without waiting out the background
+   * reconnect backoff.
+   */
+  reconnect(): void {
+    this.onchainLobWebSocketService.reconnect();
+  }
+
+  /**
    * Subscribes to the vault total values updates.
    *
    * @emits OnchainLobVault#events#vaultTotalValuesUpdated


### PR DESCRIPTION
Expose an immediate WebSocket reconnect across the client stack (OnchainLobClient / spot / vault / service / ws-client) plus an isConnected status getter. Intended for the tab-hidden/frozen case where the socket dropped and the background backoff grew to tens of seconds — reconnect() cancels the pending backoff and reconnects now, preserving all active subscriptions.

- TimeoutScheduler.reset() cancels pending timers and resets escalation
- connect() deduplicates concurrent calls so a manual reconnect can't race the background/initial connect into a second socket
- WebSocketClient.readyState returns Closed instead of throwing before the first connect, so isConnected is safe in lazy-connect mode