### PR TITLE
Feat/pyth core upgrade hermes client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .DS_Store
 .env
 dist
+.claude/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.11",
       "license": "MIT",
       "dependencies": {
-        "@pythnetwork/pyth-evm-js": "^1.83.0",
+        "@pythnetwork/hermes-client": "^2.1.0",
         "bignumber.js": "^9.1.2",
         "ethers": "^6.16.0",
         "lodash": "^4.17.21"
@@ -573,17 +573,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1683,36 +1672,18 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@pythnetwork/price-service-client": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/price-service-client/-/price-service-client-1.9.0.tgz",
-      "integrity": "sha512-SLm3IFcfmy9iMqHeT4Ih6qMNZhJEefY14T9yTlpsH2D/FE5+BaGGnfcexUifVlfH6M7mwRC4hEFdNvZ6ebZjJg==",
-      "deprecated": "This package is deprecated and is no longer maintained. Please use @pythnetwork/hermes-client instead.",
+    "node_modules/@pythnetwork/hermes-client": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/hermes-client/-/hermes-client-2.1.0.tgz",
+      "integrity": "sha512-XOtP5dvHfKNl+uvFzXCMI9OL7VdJ8eXsv5ahy6ZB3ArZ+UMM4U4OrPYQPwLvJwlpkBXpEqsJKlMawcoyCB+yMA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@pythnetwork/price-service-sdk": "*",
-        "@types/ws": "^8.5.3",
-        "axios": "^1.5.1",
-        "axios-retry": "^3.8.0",
-        "isomorphic-ws": "^4.0.1",
-        "ts-log": "^2.2.4",
-        "ws": "^8.6.0"
-      }
-    },
-    "node_modules/@pythnetwork/price-service-sdk": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/price-service-sdk/-/price-service-sdk-1.8.0.tgz",
-      "integrity": "sha512-tFZ1thj3Zja06DzPIX2dEWSi7kIfIyqreoywvw5NQ3Z1pl5OJHQGMEhxt6Li3UCGSp2ooYZS9wl8/8XfrfrNSA==",
-      "dependencies": {
-        "bn.js": "^5.2.1"
-      }
-    },
-    "node_modules/@pythnetwork/pyth-evm-js": {
-      "version": "1.83.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-evm-js/-/pyth-evm-js-1.83.0.tgz",
-      "integrity": "sha512-J70IAenLckWPUi2CvbOfOcchwlja6i8d3e8sqDtRdHO1kBTwz42X6r8BU1wAtM9cb3M7i4VyHkRHHDDGqUNWyw==",
-      "dependencies": {
-        "@pythnetwork/price-service-client": "1.9.0",
-        "buffer": "^6.0.3"
+        "@zodios/core": "^10.9.6",
+        "eventsource": "^3.0.5",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=22.14.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -2012,6 +1983,7 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
       "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2222,6 +2194,16 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@zodios/core": {
+      "version": "10.9.6",
+      "resolved": "https://registry.npmjs.org/@zodios/core/-/core-10.9.6.tgz",
+      "integrity": "sha512-aH4rOdb3AcezN7ws8vDgBfGboZMk2JGGzEq/DtW65MhnRxyTGRuLJRWVQ/2KxDgWvV2F5oTkAS+5pnjKbl0n+A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "axios": "^0.x || ^1.0.0",
+        "zod": "^3.x"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
@@ -2364,25 +2346,18 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "peer": true
     },
     "node_modules/axios": {
       "version": "1.7.9",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
       "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
-      "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2507,25 +2482,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
@@ -2533,11 +2489,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/bn.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -2611,29 +2562,6 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -2778,6 +2706,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2888,6 +2817,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3290,6 +3220,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3472,6 +3423,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -3485,6 +3437,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3700,25 +3653,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -3864,17 +3798,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-retry-allowed": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3892,14 +3815,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isomorphic-ws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "peerDependencies": {
-        "ws": "*"
-      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4737,6 +4652,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4745,6 +4661,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -5115,7 +5032,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5167,11 +5085,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5608,11 +5521,6 @@
         }
       }
     },
-    "node_modules/ts-log": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.7.tgz",
-      "integrity": "sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg=="
-    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -5949,6 +5857,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "default": "./dist/node/index.js"
   },
   "dependencies": {
-    "@pythnetwork/pyth-evm-js": "^1.83.0",
+    "@pythnetwork/hermes-client": "^2.1.0",
     "bignumber.js": "^9.1.2",
     "ethers": "^6.16.0",
     "lodash": "^4.17.21"

--- a/src/onchainLobClient.ts
+++ b/src/onchainLobClient.ts
@@ -71,6 +71,23 @@ export interface OnchainLobClientOptions {
    * @optional
    */
   fastWaitTransactionTimeout?: number;
+
+  /**
+   * API key for the Pyth Hermes price service, used when fetching price update data for
+   * vault deposits/withdrawals.
+   *
+   * @type {string}
+   * @optional
+   */
+  pythApiKey?: string;
+
+  /**
+   * Base URL of the Pyth Hermes price service. Defaults to `https://hermes.pyth.network`.
+   *
+   * @type {string}
+   * @optional
+   */
+  pythHermesUrl?: string;
 }
 
 /**

--- a/src/vault/onchainLobVault.ts
+++ b/src/vault/onchainLobVault.ts
@@ -112,6 +112,23 @@ export interface OnchainLobVaultOptions {
    * @optional
    */
   fastWaitTransactionTimeout?: number;
+
+  /**
+   * API key for the Pyth Hermes price service, used when fetching price update data for
+   * vault deposits/withdrawals.
+   *
+   * @type {string}
+   * @optional
+   */
+  pythApiKey?: string;
+
+  /**
+   * Base URL of the Pyth Hermes price service. Defaults to `https://hermes.pyth.network`.
+   *
+   * @type {string}
+   * @optional
+   */
+  pythHermesUrl?: string;
 }
 
 /**
@@ -185,6 +202,8 @@ export class OnchainLobVault implements Disposable {
   fastWaitTransaction: boolean | undefined;
   fastWaitTransactionInterval: number | undefined;
   fastWaitTransactionTimeout: number | undefined;
+  protected readonly pythApiKey: string | undefined;
+  protected readonly pythHermesUrl: string | undefined;
 
   protected signer: Signer | null;
 
@@ -201,6 +220,8 @@ export class OnchainLobVault implements Disposable {
     this.fastWaitTransaction = options.fastWaitTransaction;
     this.fastWaitTransactionInterval = options.fastWaitTransactionInterval;
     this.fastWaitTransactionTimeout = options.fastWaitTransactionTimeout;
+    this.pythApiKey = options.pythApiKey;
+    this.pythHermesUrl = options.pythHermesUrl;
     this.onchainLobService = new OnchainLobVaultService(options.apiBaseUrl);
     this.onchainLobWebSocketService = new OnchainLobVaultWebSocketService(options.webSocketApiBaseUrl);
     this.mappers = mappers;
@@ -557,6 +578,8 @@ export class OnchainLobVault implements Disposable {
         fastWaitTransaction: this.fastWaitTransaction,
         fastWaitTransactionInterval: this.fastWaitTransactionInterval,
         fastWaitTransactionTimeout: this.fastWaitTransactionTimeout,
+        pythApiKey: this.pythApiKey,
+        pythHermesUrl: this.pythHermesUrl,
       });
       this.vaultContracts.set(params.vault, vaultContract);
     }

--- a/src/vault/onchainLobVaultContract.ts
+++ b/src/vault/onchainLobVaultContract.ts
@@ -12,7 +12,7 @@ import { erc20Abi, erc20WethAbi, lpManagerAbi } from '../abi';
 import type { VaultConfig } from '../models';
 import { tokenUtils } from '../utils';
 import { wait } from '../utils/delay';
-import { EvmPriceServiceConnection } from '@pythnetwork/pyth-evm-js';
+import { HermesClient } from '@pythnetwork/hermes-client';
 
 export interface OnchainLobVaultContractOptions {
   vault: VaultConfig;
@@ -21,6 +21,8 @@ export interface OnchainLobVaultContractOptions {
   fastWaitTransaction?: boolean;
   fastWaitTransactionInterval?: number;
   fastWaitTransactionTimeout?: number;
+  pythApiKey?: string;
+  pythHermesUrl?: string;
 }
 
 const getExpires = () => BigInt(Math.floor(Date.now() / 1000) + 5 * 60);
@@ -29,6 +31,7 @@ export class OnchainLobVaultContract {
   static readonly defaultAutoWaitTransaction = true;
   static readonly defaultFastWaitTransaction = false;
   static readonly defaultFastWaitTransactionInterval = 100;
+  static readonly defaultPythHermesUrl = 'https://hermes.pyth.network';
 
   readonly vault: VaultConfig;
   autoWaitTransaction: boolean;
@@ -49,7 +52,7 @@ export class OnchainLobVaultContract {
     return Promise.resolve(this._chainId);
   }
 
-  protected pythConnection: EvmPriceServiceConnection;
+  protected pythConnection: HermesClient;
 
   constructor(options: Readonly<OnchainLobVaultContractOptions>) {
     this.vault = options.vault;
@@ -60,7 +63,10 @@ export class OnchainLobVaultContract {
     this.fastWaitTransactionTimeout = options.fastWaitTransactionTimeout;
 
     this.vaultContract = new Contract(options.vault.vaultAddress, lpManagerAbi, options.signer);
-    this.pythConnection = new EvmPriceServiceConnection('https://hermes.pyth.network');
+    this.pythConnection = new HermesClient(
+      options.pythHermesUrl ?? OnchainLobVaultContract.defaultPythHermesUrl,
+      options.pythApiKey ? { headers: { Authorization: `Bearer ${options.pythApiKey}` } } : {}
+    );
   }
 
   async approveTokens(params: ApproveVaultParams): Promise<ContractTransactionResponse> {
@@ -292,8 +298,9 @@ export class OnchainLobVaultContract {
 
   protected async getPriceUpdateData(feedPriceIds: string[]): Promise<string[]> {
     try {
-      const updateData = await this.pythConnection.getPriceFeedsUpdateData(feedPriceIds);
-      return updateData;
+      const priceUpdates = await this.pythConnection.getLatestPriceUpdates(feedPriceIds, { encoding: 'hex' });
+      // Hermes returns hex-encoded update data without the `0x` prefix; the Pyth contract expects `bytes`.
+      return priceUpdates.binary.data.map(data => data.startsWith('0x') ? data : `0x${data}`);
     }
     catch (error) {
       console.error('Failed to get price update data from pyth:', error);


### PR DESCRIPTION
## What & why

Pyth's Core upgrade (2026-07-31) deprecates `@pythnetwork/pyth-evm-js` / `EvmPriceServiceConnection`, and Hermes starts enforcing API-key auth. This migrates the vault's Pyth integration off the deprecated package so vault deposits/withdrawals keep working after cutover.

## Changes

- Replace `@pythnetwork/pyth-evm-js` → `@pythnetwork/hermes-client` (`HermesClient`)
- `getPriceUpdateData` now uses `getLatestPriceUpdates({ encoding: 'hex' })` and `0x`-prefixes `binary.data` (Hermes returns hex without it); PNAU format is accepted by the on-chain Pyth contract as before
- New `pythApiKey` / `pythHermesUrl` options threaded `OnchainLobClientOptions → OnchainLobVaultOptions → OnchainLobVaultContractOptions`; key sent as `Authorization: Bearer <key>`

## Usage

Frontends point at a backend proxy and omit the key (Pyth forbids embedding the secret key in browsers):
```ts
new OnchainLobClient({ /* ... */, pythHermesUrl: 'https://api-base.hanji.io/pyth/hermes' })
