### PR TITLE
feat: expose vaultType on vault list and config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ export type {
 
   VaultListItem,
   VaultConfig,
+  VaultType,
   VaultTotalValues,
   VaultTotalValuesUpdate,
   VaultHistory,

--- a/src/models/vault.ts
+++ b/src/models/vault.ts
@@ -7,6 +7,13 @@ import { Token } from './common';
 export type DepositActionDirection = 'deposit' | 'withdraw';
 
 /**
+ * The type of vault, determined by the factory that deployed it.
+ * - `LPManager`: classic single-token/multi-token LP manager vault.
+ * - `LPManagerPair`: pair vault deployed by the LPManagerPair factory.
+ */
+export type VaultType = 'LPManager' | 'LPManagerPair';
+
+/**
  * Represents the dynamic vault values.
  */
 export interface VaultTotalValues {
@@ -296,6 +303,11 @@ export type VaultListItem = {
    * The vault's total volume in usd
    */
   totalVolume: number;
+
+  /**
+   * The vault's type (LPManager or LPManagerPair)
+   */
+  vaultType: VaultType;
 };
 
 /**
@@ -386,6 +398,11 @@ export type VaultConfig = {
     feeBps: number;
     taxBps: number;
   };
+
+  /**
+   * The vault's type (LPManager or LPManagerPair)
+   */
+  vaultType: VaultType;
 };
 
 /**

--- a/src/services/onchainLobVaultService/dtos.ts
+++ b/src/services/onchainLobVaultService/dtos.ts
@@ -1,4 +1,4 @@
-import type { DepositActionDirection } from '../../models';
+import type { DepositActionDirection, VaultType } from '../../models';
 import { TokenDto } from '../onchainLobSpotService';
 
 export interface VaultListItemDto {
@@ -17,6 +17,7 @@ export interface VaultListItemDto {
   isUserGenerated: boolean;
   isDeprecated: boolean;
   totalVolume: number;
+  vaultType: VaultType;
 }
 
 export interface VaultConfigDto {
@@ -40,6 +41,7 @@ export interface VaultConfigDto {
     feeBps: number;
     taxBps: number;
   };
+  vaultType: VaultType;
 }
 
 export interface VaultDepositActionDto {


### PR DESCRIPTION
Mirror the backend change that distinguishes LPManagerPair vaults: add a VaultType ('LPManager' | 'LPManagerPair') and surface it via getVaultsList and getVaultConfig. getVaultsList returns the DTO as-is and the vault-config mapper spreads the DTO, so the field flows through without mapper changes.